### PR TITLE
POC: use KafkaStreamsAssignment instead of UUID as generic parameter of RackAwareGraphConstructor

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareGraphConstructor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareGraphConstructor.java
@@ -32,6 +32,7 @@ import org.apache.kafka.streams.processor.internals.assignment.RackAwareTaskAssi
 
 /**
  * Construct graph for rack aware task assignor
+ * @param <T> represents a KafkaStreams client and its currently-assigned tasks
  */
 public interface RackAwareGraphConstructor<T> {
     int SOURCE_ID = -1;


### PR DESCRIPTION
Put together this POC to see if I could simplify the rack-aware stuff in TaskAssignmentUtils from [PR 9](https://github.com/apache/kafka/pull/16033). This was based on an observation that the assignment in `ClientState` was mutable but the `KafkaStreamsAssignment` was not, and that this was causing a lot of problems and unnecessary data structure manipulations/conversions (not just in PR 9 but all throughout the KIP-924 code).

So I figured maybe we could add a few new methods to KafkaStreamsAssignment to allow in-place updates (ie adding/removing tasks). This meant we could drop in the KafkaStreamsAssignment as the generic parameter of the RackAwareGraphConstructor and resolve some of the lingering issues about how to compute the `hasAssignedTask` parameter (see [this](https://github.com/apache/kafka/pull/16033/files#r1618277981) or [this comment](https://github.com/apache/kafka/pull/16033/files#r1618135137))

I think it turned out pretty much as I was hoping it would, and helped sort out a lot of the logic around the RackAwareGraphConstructor. I also think being able to update the `KafkaStreamsAssignment` objects after creation will help with iterative-style assignment algorithms, which will be useful both to custom assignor implementers as well as to the existing out-of-the-box assignors already using an iterative assignment approach in Kafka Streams.

Note: this POC is strictly about simplifying the TaskAssignmentUtils by adding the `#assignTask` and `#removeTask` methods to KafkaStreamsAssignment. It doesn't do any other API improvements we've discussed before, but it does  include a few `TODOs` in the code to point out additional places where things can be further simplified once those others changes are made, such as having `ApplicationState#allTasks` return a `Map<TaskId, TaskInfo>` or potentially changing the `KafkaStreamsAssignment#assignment` API's return type to be a map when we go to change the name of this method from `#assignment` to `#tasks` (See TODOs in code for more details on the latter option)